### PR TITLE
Implement initial memory search CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # MemoryManagerForCodex
-Memory Manager for OpenAI Codex CLI
+
+Memory Manager for OpenAI Codex CLI.
+
+## Codex Memory Search
+
+The project ships a `codex` command line tool that can search project or global
+memories stored in `CODEX.md` files.
+
+### Usage
+
+```bash
+codex mem:search "query" [--scope project|global|module] [--k N]
+```
+
+- `--scope` selects which `CODEX.md` to search:
+  - `project` (default) looks for `.codex/CODEX.md` in the current directory.
+  - `global` searches `~/.codex/memory/CODEX.md`.
+  - `module` may be used for future module-specific memories.
+- `--k` limits the number of results returned (default 5).
+
+If no `CODEX.md` exists for the selected scope, the command prints a helpful
+message instead of failing.

--- a/codex/__init__.py
+++ b/codex/__init__.py
@@ -1,0 +1,2 @@
+"""Codex CLI package."""
+__all__ = []

--- a/codex/cli.py
+++ b/codex/cli.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from .memory import search_codex
+
+
+def resolve_codex_path(scope: str) -> Path:
+    if scope == "global":
+        return Path.home() / ".codex" / "memory" / "CODEX.md"
+    # default project scope
+    return Path(".codex") / "CODEX.md"
+
+
+@click.group()
+def cli() -> None:
+    """Codex command line interface."""
+
+
+@cli.command("mem:search")
+@click.argument("query")
+@click.option("--scope", default="project", type=click.Choice(["project", "global", "module"]))
+@click.option("--k", default=5, type=int)
+def mem_search(query: str, scope: str, k: int) -> None:
+    """Search CODEX memories."""
+    path = resolve_codex_path(scope)
+    if not path.exists():
+        click.echo(f"No CODEX.md found for scope '{scope}' at {path}")
+        return
+    results = search_codex(path, query, k)
+    for e in results:
+        tags = f" [{', '.join(e.tags)}]" if e.tags else ""
+        click.echo(f"[{e.section}] ({e.id}) {e.text}{tags}")
+
+
+if __name__ == "__main__":
+    cli()

--- a/codex/memory.py
+++ b/codex/memory.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import List, Dict, Iterable, Optional
+
+import yaml
+
+
+SECTION_WEIGHTS: Dict[str, float] = {
+    "Preferences": 1.0,
+    "Project Facts": 1.2,
+    "Guardrails": 1.5,
+    "Playbooks": 1.0,
+    "Open Questions": 0.8,
+}
+
+
+@dataclass
+class Entry:
+    id: str
+    section: str
+    tags: List[str]
+    text: str
+    updated: Optional[str] = None
+
+
+TOKEN_RE = re.compile(r"\w+")
+
+
+def tokenize(s: str) -> List[str]:
+    return TOKEN_RE.findall(s.lower())
+
+
+def load_codex_entries(path: Path) -> List[Entry]:
+    """Parse CODEX.md into entries."""
+    entries: List[Entry] = []
+    if not path.exists():
+        return entries
+
+    lines = path.read_text().splitlines()
+    section: Optional[str] = None
+    i = 0
+    while i < len(lines):
+        line = lines[i].rstrip()
+        if line.startswith("## "):
+            section = line[3:].strip()
+            i += 1
+            continue
+        if line.startswith("- "):
+            entry_lines = [line]
+            i += 1
+            while i < len(lines):
+                next_line = lines[i]
+                if next_line.startswith("- ") or next_line.startswith("## "):
+                    break
+                if next_line.strip() == "":
+                    entry_lines.append(next_line)
+                    i += 1
+                    continue
+                entry_lines.append(next_line)
+                i += 1
+            data = yaml.safe_load("\n".join(entry_lines))
+            if isinstance(data, list) and data:
+                raw = data[0]
+                entry = Entry(
+                    id=str(raw.get("id", "")),
+                    section=section or "",
+                    tags=[str(t) for t in raw.get("tags", [])],
+                    text=str(raw.get("text", "")),
+                    updated=raw.get("updated"),
+                )
+                entries.append(entry)
+        else:
+            i += 1
+    return entries
+
+
+def score_entry(entry: Entry, query_tokens: Iterable[str]) -> float:
+    entry_tokens = set(
+        tokenize(entry.id) + entry.tags + tokenize(entry.text[:128])
+    )
+    matches = sum(1 for t in query_tokens if t in entry_tokens)
+    if matches == 0:
+        return 0.0
+    weight = SECTION_WEIGHTS.get(entry.section, 1.0)
+    recency = 1.0
+    if entry.updated:
+        try:
+            dt = datetime.fromisoformat(entry.updated)
+            age_days = (datetime.now() - dt).days
+            recency = 1 / math.sqrt(1 + age_days)
+        except Exception:
+            pass
+    return matches * weight * recency
+
+
+def search_codex(path: Path, query: str, k: int = 5) -> List[Entry]:
+    entries = load_codex_entries(path)
+    tokens = tokenize(query)
+    scored = [
+        (score_entry(e, tokens), e) for e in entries
+    ]
+    scored = [se for se in scored if se[0] > 0]
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return [e for _, e in scored[:k]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "codex"
+version = "0.1.0"
+dependencies = [
+    "click",
+    "PyYAML",
+]
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/tasks.md
+++ b/tasks.md
@@ -3,9 +3,9 @@
 This file outlines implementation tasks for the Codex CLI and MCP, derived from `codex_local_memory_design_full.md`.
 
 ## CLI - Memory Commands
-- [ ] **Search**: Implement `codex mem:search <query> [--scope <scope>] [--k <k>]` to query CODEX.md files.
-  - [ ] Build in-memory index from CODEX.md with weights and recency.
-  - [ ] **Tests**: Ensure search returns expected entries by section, honors scope/k limits, and handles missing files gracefully.
+- [x] **Search**: Implement `codex mem:search <query> [--scope <scope>] [--k <k>]` to query CODEX.md files.
+  - [x] Build in-memory index from CODEX.md with weights and recency.
+  - [x] **Tests**: Ensure search returns expected entries by section, honors scope/k limits, and handles missing files gracefully.
 - [ ] **Add**: Implement `codex mem:add <Section> --id <id> --tags <tags> --text <text>`.
   - [ ] Write to CODEX.md with dry-run diff, lock file, and secret redaction.
   - [ ] **Tests**: Verify diff output, lock enforcement on concurrent writes, redaction, and successful append.

--- a/tests/test_mem_search.py
+++ b/tests/test_mem_search.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+from click.testing import CliRunner
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from codex.cli import cli
+
+
+PROJECT_CODEX = """# CODEX Memory
+
+## Preferences
+- id: pref-js-style
+  tags: [style, js]
+  text: "Use 2-space indent; no semicolons."
+
+## Guardrails
+- id: guard-db
+  tags: [safety, db]
+  text: "Never run destructive migrations."
+
+## Project Facts
+- id: fact-one
+  tags: [project]
+  text: "project uses microservices"
+- id: fact-two
+  tags: [project]
+  text: "project uses database"
+"""
+
+GLOBAL_CODEX = """# CODEX Memory
+
+## Project Facts
+- id: global-fact
+  tags: [global]
+  text: "global memory entry"
+"""
+
+
+def test_search_returns_section_and_entry():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path('.codex').mkdir()
+        Path('.codex/CODEX.md').write_text(PROJECT_CODEX)
+        result = runner.invoke(cli, ['mem:search', 'indent'])
+        assert 'pref-js-style' in result.output
+        assert '[Preferences]' in result.output
+        assert result.exit_code == 0
+
+
+def test_scope_and_k_limit():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path('.codex').mkdir()
+        Path('.codex/CODEX.md').write_text(PROJECT_CODEX)
+        home = Path('home')
+        (home / '.codex/memory').mkdir(parents=True)
+        (home / '.codex/memory/CODEX.md').write_text(GLOBAL_CODEX)
+        env = {'HOME': str(home)}
+        result = runner.invoke(cli, ['mem:search', 'global', '--scope', 'global'], env=env)
+        assert 'global-fact' in result.output
+        assert '[Project Facts]' in result.output
+        result = runner.invoke(cli, ['mem:search', 'project', '--k', '1'], env=env)
+        lines = [l for l in result.output.strip().splitlines() if l]
+        assert len(lines) == 1
+
+
+def test_missing_file_handled():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ['mem:search', 'anything'])
+        assert 'No CODEX.md found' in result.output
+        assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- add `codex mem:search` command with scope and result limits
- parse CODEX.md entries into an in-memory index with weighting and recency scoring
- cover CLI search behavior with pytest tests
- document `mem:search` CLI usage in README
- mark `mem:search` task complete in `tasks.md`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a89780b1888333b4466f08556a038b