### PR TITLE
feat: add CLI command for appending memories

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,14 @@ codex mem:search "query" [--scope project|global|module] [--k N]
 
 If no `CODEX.md` exists for the selected scope, the command prints a helpful
 message instead of failing.
+
+## Codex Memory Add
+
+You can append new memories to `CODEX.md` using the `mem:add` command:
+
+```bash
+codex mem:add <Section> --id <id> --tags <tag1,tag2> --text "content" [--scope project|global|module]
+```
+
+The command acquires a lock while writing, redacts obvious secrets, and prints a
+unified diff of the changes before committing them.

--- a/codex/cli.py
+++ b/codex/cli.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from pathlib import Path
+import difflib
 
 import click
 
-from .memory import search_codex
+from .memory import search_codex, redact
 
 
 def resolve_codex_path(scope: str) -> Path:
@@ -33,6 +34,58 @@ def mem_search(query: str, scope: str, k: int) -> None:
     for e in results:
         tags = f" [{', '.join(e.tags)}]" if e.tags else ""
         click.echo(f"[{e.section}] ({e.id}) {e.text}{tags}")
+
+
+@cli.command("mem:add")
+@click.argument("section")
+@click.option("--id", "id_", required=True)
+@click.option("--tags", default="", help="Comma-separated tags")
+@click.option("--text", required=True)
+@click.option("--scope", default="project", type=click.Choice(["project", "global", "module"]))
+def mem_add(section: str, id_: str, tags: str, text: str, scope: str) -> None:
+    """Add an entry to CODEX.md."""
+    path = resolve_codex_path(scope)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_name(path.name + ".lock")
+    try:
+        lock_path.open("x").close()
+    except FileExistsError:
+        click.echo(f"Lock file exists at {lock_path}")
+        return
+    try:
+        original = "# CODEX Memory\n" if not path.exists() else path.read_text()
+        if not original.endswith("\n"):
+            original += "\n"
+        lines = original.splitlines()
+        section_header = f"## {section}"
+        if section_header not in lines:
+            if lines and lines[-1] != "":
+                lines.append("")
+            lines.append(section_header)
+        section_index = lines.index(section_header)
+        insert_at = section_index + 1
+        while insert_at < len(lines) and not lines[insert_at].startswith("## "):
+            insert_at += 1
+        tags_list = [t.strip() for t in tags.split(",") if t.strip()]
+        entry_lines = [
+            f"- id: {id_}",
+            f"  tags: [{', '.join(tags_list)}]",
+            f"  text: \"{redact(text)}\"",
+        ]
+        lines[insert_at:insert_at] = entry_lines + ([""] if insert_at < len(lines) else [])
+        new_text = "\n".join(lines) + "\n"
+        diff = "\n".join(
+            difflib.unified_diff(
+                original.splitlines(),
+                new_text.splitlines(),
+                fromfile=str(path),
+                tofile=str(path),
+            )
+        )
+        click.echo(diff)
+        path.write_text(new_text)
+    finally:
+        lock_path.unlink(missing_ok=True)
 
 
 if __name__ == "__main__":

--- a/codex/memory.py
+++ b/codex/memory.py
@@ -5,7 +5,7 @@ import re
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import List, Dict, Iterable, Optional
+from typing import Iterable, List, Dict, Optional
 
 import yaml
 
@@ -33,6 +33,17 @@ TOKEN_RE = re.compile(r"\w+")
 
 def tokenize(s: str) -> List[str]:
     return TOKEN_RE.findall(s.lower())
+
+
+RE_EMAIL = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+RE_SECRET = re.compile(r"[A-Za-z0-9]{20,}")
+
+
+def redact(text: str) -> str:
+    """Redact obvious secrets like emails and long tokens."""
+    text = RE_EMAIL.sub("<redacted:email>", text)
+    text = RE_SECRET.sub("<redacted:secret>", text)
+    return text
 
 
 def load_codex_entries(path: Path) -> List[Entry]:

--- a/tasks.md
+++ b/tasks.md
@@ -6,9 +6,9 @@ This file outlines implementation tasks for the Codex CLI and MCP, derived from 
 - [x] **Search**: Implement `codex mem:search <query> [--scope <scope>] [--k <k>]` to query CODEX.md files.
   - [x] Build in-memory index from CODEX.md with weights and recency.
   - [x] **Tests**: Ensure search returns expected entries by section, honors scope/k limits, and handles missing files gracefully.
-- [ ] **Add**: Implement `codex mem:add <Section> --id <id> --tags <tags> --text <text>`.
-  - [ ] Write to CODEX.md with dry-run diff, lock file, and secret redaction.
-  - [ ] **Tests**: Verify diff output, lock enforcement on concurrent writes, redaction, and successful append.
+- [x] **Add**: Implement `codex mem:add <Section> --id <id> --tags <tags> --text <text>`.
+  - [x] Write to CODEX.md with dry-run diff, lock file, and secret redaction.
+  - [x] **Tests**: Verify diff output, lock enforcement on concurrent writes, redaction, and successful append.
 - [ ] **Update**: Implement `codex mem:update <id> --text <text> [--tags <tags>]`.
   - [ ] Apply in-place edit via patch with confirmation.
   - [ ] **Tests**: Confirm fields are updated correctly and diff is shown before write.

--- a/tests/test_mem_add.py
+++ b/tests/test_mem_add.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+from click.testing import CliRunner
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from codex.cli import cli
+
+
+def test_mem_add_appends_with_diff_and_redaction():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path('.codex').mkdir()
+        Path('.codex/CODEX.md').write_text('# CODEX Memory\n\n## Preferences\n')
+        cmd = [
+            'mem:add',
+            'Preferences',
+            '--id', 'pref-new',
+            '--tags', 'test',
+            '--text', 'Reach me at user@example.com with key ABCDEFGHIJKLMNOPQRST',
+        ]
+        result = runner.invoke(cli, cmd)
+        assert result.exit_code == 0
+        assert '+- id: pref-new' in result.output
+        content = Path('.codex/CODEX.md').read_text()
+        assert 'user@example.com' not in content
+        assert '<redacted:email>' in content
+        assert '<redacted:secret>' in content
+
+
+def test_mem_add_respects_lock_file():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path('.codex').mkdir()
+        Path('.codex/CODEX.md').write_text('# CODEX Memory\n')
+        Path('.codex/CODEX.md.lock').write_text('')
+        cmd = [
+            'mem:add',
+            'Preferences',
+            '--id', 'pref-blocked',
+            '--tags', 't',
+            '--text', 'blocked',
+        ]
+        result = runner.invoke(cli, cmd)
+        assert 'lock file exists' in result.output.lower()
+        content = Path('.codex/CODEX.md').read_text()
+        assert 'pref-blocked' not in content


### PR DESCRIPTION
## Summary
- add `mem:add` CLI for writing new entries with diff output and file locking
- redact emails and long tokens before writing to CODEX
- document `mem:add` usage and mark related task complete

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a92457177c8333a550a6ee5481729a