### PR TITLE
feat: add memory update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,15 @@ codex mem:add <Section> --id <id> --tags <tag1,tag2> --text "content" [--scope p
 
 The command acquires a lock while writing, redacts obvious secrets, and prints a
 unified diff of the changes before committing them.
+
+## Codex Memory Update
+
+Existing memories can be modified with the `mem:update` command:
+
+```bash
+codex mem:update <id> --text "new content" [--tags tag1,tag2] [--scope project|global|module]
+```
+
+The command shows a unified diff of the changes and requires confirmation before
+overwriting the entry. The text is redacted for obvious secrets, and an
+`updated` timestamp is recorded.

--- a/codex/cli.py
+++ b/codex/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import difflib
+from datetime import datetime
 
 import click
 
@@ -86,6 +87,86 @@ def mem_add(section: str, id_: str, tags: str, text: str, scope: str) -> None:
         path.write_text(new_text)
     finally:
         lock_path.unlink(missing_ok=True)
+
+
+@cli.command("mem:update")
+@click.argument("id_")
+@click.option("--text", required=True)
+@click.option("--tags", default="", help="Comma-separated tags")
+@click.option("--scope", default="project", type=click.Choice(["project", "global", "module"]))
+def mem_update(id_: str, text: str, tags: str, scope: str) -> None:
+    """Update an existing entry in CODEX.md."""
+    path = resolve_codex_path(scope)
+    if not path.exists():
+        click.echo(f"No CODEX.md found for scope '{scope}' at {path}")
+        return
+
+    original = path.read_text()
+    lines = original.splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip() == f"- id: {id_}":
+            start = i
+            break
+    if start is None:
+        click.echo(f"Entry {id_} not found")
+        return
+
+    end = start + 1
+    while end < len(lines) and not lines[end].startswith("- id: ") and not lines[end].startswith("## "):
+        end += 1
+
+    entry_lines = lines[start:end]
+    tags_list = [t.strip() for t in tags.split(",") if t.strip()]
+
+    # indices of fields within entry_lines
+    idx_tags = next((i for i, l in enumerate(entry_lines[1:], start=1) if l.startswith("  tags:")), None)
+    idx_text = next((i for i, l in enumerate(entry_lines[1:], start=1) if l.startswith("  text:")), None)
+    idx_updated = next((i for i, l in enumerate(entry_lines[1:], start=1) if l.startswith("  updated:")), None)
+
+    if tags_list:
+        tags_line = f"  tags: [{', '.join(tags_list)}]"
+        if idx_tags is not None:
+            entry_lines[idx_tags] = tags_line
+        else:
+            entry_lines.insert(1, tags_line)
+            if idx_text is not None:
+                idx_text += 1
+            if idx_updated is not None:
+                idx_updated += 1
+
+    redacted = redact(text)
+    text_line = f"  text: \"{redacted}\""
+    if idx_text is not None:
+        entry_lines[idx_text] = text_line
+    else:
+        insert_at = 2 if (tags_list or idx_tags is not None) else 1
+        entry_lines.insert(insert_at, text_line)
+        if idx_updated is not None:
+            idx_updated += 1
+
+    updated_line = f"  updated: \"{datetime.now().isoformat()}\""
+    if idx_updated is not None:
+        entry_lines[idx_updated] = updated_line
+    else:
+        insert_at = (idx_text if idx_text is not None else len(entry_lines) - 1) + 1
+        entry_lines.insert(insert_at, updated_line)
+
+    lines[start:end] = entry_lines
+    new_text = "\n".join(lines) + "\n"
+    diff = "\n".join(
+        difflib.unified_diff(
+            original.splitlines(),
+            new_text.splitlines(),
+            fromfile=str(path),
+            tofile=str(path),
+        )
+    )
+    click.echo(diff)
+    if click.confirm("Apply changes?", default=False):
+        path.write_text(new_text)
+    else:
+        click.echo("Aborted")
 
 
 if __name__ == "__main__":

--- a/tasks.md
+++ b/tasks.md
@@ -9,9 +9,9 @@ This file outlines implementation tasks for the Codex CLI and MCP, derived from 
 - [x] **Add**: Implement `codex mem:add <Section> --id <id> --tags <tags> --text <text>`.
   - [x] Write to CODEX.md with dry-run diff, lock file, and secret redaction.
   - [x] **Tests**: Verify diff output, lock enforcement on concurrent writes, redaction, and successful append.
-- [ ] **Update**: Implement `codex mem:update <id> --text <text> [--tags <tags>]`.
-  - [ ] Apply in-place edit via patch with confirmation.
-  - [ ] **Tests**: Confirm fields are updated correctly and diff is shown before write.
+- [x] **Update**: Implement `codex mem:update <id> --text <text> [--tags <tags>]`.
+  - [x] Apply in-place edit via patch with confirmation.
+  - [x] **Tests**: Confirm fields are updated correctly and diff is shown before write.
 - [ ] **Delete**: Implement `codex mem:delete <id> [--yes]`.
   - [ ] Mark entry archived with `ttl: "0d"` or remove on confirmation.
   - [ ] **Tests**: Verify deletion behavior with and without `--yes` flag.

--- a/tests/test_mem_update.py
+++ b/tests/test_mem_update.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+from click.testing import CliRunner
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from codex.cli import cli
+
+
+def test_mem_update_patches_entry_with_confirmation():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path('.codex').mkdir()
+        Path('.codex/CODEX.md').write_text('# CODEX Memory\n\n## Preferences\n- id: pref-one\n  tags: [t1]\n  text: "old"\n')
+        cmd = [
+            'mem:update',
+            'pref-one',
+            '--text', 'new',
+            '--tags', 't2',
+        ]
+        result = runner.invoke(cli, cmd, input='y\n')
+        assert result.exit_code == 0
+        # diff shows old and new text
+        assert '-  text: "old"' in result.output
+        assert '+  text: "new"' in result.output
+        content = Path('.codex/CODEX.md').read_text()
+        assert 'pref-one' in content
+        assert 't2' in content
+        assert 'new' in content
+        assert 'old' not in content
+        assert 'updated:' in content


### PR DESCRIPTION
## Summary
- implement `mem:update` CLI to patch existing CODEX entries with confirmation and timestamp
- document update usage and mark task complete
- test updating entries and diff display

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68a92da4129c8333929aed5e4b88bd6e